### PR TITLE
Add some symlinks for hub4j/github-api#875

### DIFF
--- a/ghcontent-ro/a-symlink-to-a-dir
+++ b/ghcontent-ro/a-symlink-to-a-dir
@@ -1,0 +1,1 @@
+a-dir-with-3-entries

--- a/ghcontent-ro/a-symlink-to-a-file
+++ b/ghcontent-ro/a-symlink-to-a-file
@@ -1,0 +1,1 @@
+a-file-with-content


### PR DESCRIPTION
Add some symlinks for integration tests.

easier to see in https://github.com/hub4j-test-org/GHContentIntegrationTest/tree/b1bfe76b86d3fe4e0bbdf2ee3a82e3aba2b3e28d/ghcontent-ro as the symlinks do not show as such in the "files changed" tab